### PR TITLE
Automatic MIME Type Resolution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,5 +5,5 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPPILE_COMMANDS ON)
 
-add_executable(main src/main.cpp src/threadpool.cpp src/http.cpp)
+add_executable(main src/main.cpp src/threadpool.cpp src/http.cpp src/mime.cpp)
 target_include_directories(main PRIVATE include/)

--- a/include/mime.h
+++ b/include/mime.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+class MIMEType {
+private:
+  std::string type;
+  std::string subtype;
+public:
+  MIMEType(std::string type, std::string subtype);
+  std::string toString();
+};
+
+class MIME {
+private:
+  std::unordered_map<std::string, MIMEType> extMIME;
+public:
+  MIME();
+  std::string getMIMEType(std::string resource);
+};

--- a/src/http.cpp
+++ b/src/http.cpp
@@ -96,7 +96,7 @@ std::string http::Request::getHeader(std::string key) {
 };
 
 void http::Request::setHeader(std::string key, std::string value) {
-  this->headers.insert(std::make_pair(key, value));
+  this->headers[key] = value;
 };
 
 size_t http::Request::serialize(std::unique_ptr<unsigned char[]>& out) {
@@ -105,7 +105,7 @@ size_t http::Request::serialize(std::unique_ptr<unsigned char[]>& out) {
                              + http::version_as_string(this->getVersion()) + "\r\n";
   std::string headers = "";
   for (auto header : this->getHeaders()) {
-    headers += (header.first + ": " + header.second + "\r\n");
+    headers += (header.first + ":" + header.second + "\r\n");
   }
 
   std::string text = request_line + headers + "\r\n";
@@ -202,7 +202,7 @@ std::string http::Response::getHeader(std::string key) {
 };
 
 void http::Response::setHeader(std::string key, std::string value) {
-  this->headers.insert(std::make_pair(key, value));
+  this->headers[key] = value;
 };
 
  std::unique_ptr<unsigned char[]> http::Response::getData() {
@@ -224,7 +224,7 @@ size_t  http::Response::serialize(std::unique_ptr<unsigned char[]>& out) {
 
   head += version + " " + code + " " + statusText + "\r\n";
   for (auto header : this->headers) {
-    head += header.first + " : " + header.second + "\r\n";
+    head += header.first + ":" + header.second + "\r\n";
   }
   head += "\r\n";
 
@@ -239,7 +239,6 @@ std::map<std::string, std::string> http::Response::getDefaultReponseHeaders() {
   return {
       std::make_pair("Content-Type", "text/html; charset=UTF-8"),
       std::make_pair("Content-Encoding", "UTF-8"),
-      std::make_pair("Accept", "*/*"),
     };
 };
 

--- a/src/mime.cpp
+++ b/src/mime.cpp
@@ -1,0 +1,28 @@
+#include "mime.h"
+#include <iostream>
+
+MIMEType::MIMEType(std::string type, std::string subtype) {
+  this->type = type;
+  this->subtype = subtype;
+}
+
+std::string MIMEType::toString() {
+  return this->type + "/" + this->subtype;
+}
+
+MIME::MIME() {
+  this->extMIME = std::unordered_map<std::string, MIMEType>{
+      {".js", MIMEType{"text", "javascript"}},
+      {".css", MIMEType{"text", "css"}},
+      {".html", MIMEType{"text", "html"}},
+      {".ico", MIMEType{"image","x-icon"}},
+  };
+}
+
+std::string MIME::getMIMEType(std::string resource) {
+  std::string ext = resource.substr(resource.find_last_of("."));
+  std::cout << "EXTENSION: " + ext << std::endl;
+  MIMEType type = this->extMIME.at(ext);
+  std::cout << "MIME: " + type.toString() << std::endl;
+  return type.toString(); 
+}


### PR DESCRIPTION
Implemented a class for automatically resolving the MIME type of a given resource.
Under the hood, it utilizes a hash-map from the file extension to a sane MIME type for said extension. Right now this map is limited to MIME types and extensions used by the server project for testing.